### PR TITLE
Encryption documentation

### DIFF
--- a/modules/user/outputs.tf
+++ b/modules/user/outputs.tf
@@ -28,21 +28,21 @@ output "console_password" {
   description = "Encrypted password for AWS console and services access."
 
   value = {
-    encrypted_password  = join("", aws_iam_user_login_profile.this[*].encrypted_password)
-    pgp_key_fingerprint = join("", aws_iam_user_login_profile.this[*].key_fingerprint)
+    encrypted_password_base64  = join("", aws_iam_user_login_profile.this[*].encrypted_password)
+    pgp_key_fingerprint        = join("", aws_iam_user_login_profile.this[*].key_fingerprint)
   }
 }
 
 output "access_keys" {
-  description = "AWS API access keys, of whih there can be no more than two regardless of state."
+  description = "AWS API access keys, of which there can be no more than two regardless of status."
 
   value = [ for key in var.access_keys : {
-    name                           = key.name
-    id                             = aws_iam_access_key.this[key.name].id
-    status                         = aws_iam_access_key.this[key.name].status
-    encrypted_secret               = aws_iam_access_key.this[key.name].encrypted_secret
-    encrypted_ses_smtp_password_v4 = aws_iam_access_key.this[key.name].encrypted_ses_smtp_password_v4
-    pgp_key_fingerprint            = aws_iam_access_key.this[key.name].key_fingerprint
+    name                                  = key.name
+    id                                    = aws_iam_access_key.this[key.name].id
+    status                                = aws_iam_access_key.this[key.name].status
+    encrypted_secret_base64               = aws_iam_access_key.this[key.name].encrypted_secret
+    encrypted_ses_smtp_password_v4_base64 = aws_iam_access_key.this[key.name].encrypted_ses_smtp_password_v4
+    pgp_key_fingerprint                   = aws_iam_access_key.this[key.name].key_fingerprint
   }]
 }
 

--- a/modules/user/outputs.tf
+++ b/modules/user/outputs.tf
@@ -36,14 +36,13 @@ output "console_password" {
 output "access_keys" {
   description = "AWS API access keys, of which there can be no more than two regardless of status."
 
-  value = [ for key in var.access_keys : {
-    name                                  = key.name
+  value = { for key in var.access_keys : key.name => {
     id                                    = aws_iam_access_key.this[key.name].id
     status                                = aws_iam_access_key.this[key.name].status
     encrypted_secret_base64               = aws_iam_access_key.this[key.name].encrypted_secret
     encrypted_ses_smtp_password_v4_base64 = aws_iam_access_key.this[key.name].encrypted_ses_smtp_password_v4
     pgp_key_fingerprint                   = aws_iam_access_key.this[key.name].key_fingerprint
-  }]
+  }}
 }
 
 output "virtual_mfa_device" {

--- a/tests/main.tf
+++ b/tests/main.tf
@@ -50,7 +50,7 @@ module "users_groups" {
       groups = [ "Administrators" ]
     }
 
-    clusterdaemon = {
+    ClusterDaemon = {
       enable_mfa  = true
       pgp = {
         keybase_username = "clusterdaemon"


### PR DESCRIPTION
Updated documentation with instructions for decrypting secret output values.

Update the users module output to better call values what they are with respect to contents

Changed the output schema of access_keys, opting for a map of objects rather than a list of objects. This helps to address keys by their given name when integrating this module, which is a value that is always known before apply and does not affect AWS resources.